### PR TITLE
fix(i18n): make translation model configurable

### DIFF
--- a/.github/workflows/llm-translate.yaml
+++ b/.github/workflows/llm-translate.yaml
@@ -76,6 +76,7 @@ jobs:
         if: steps.pick.outputs.has_files == 'true'
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_MODEL: ${{ vars.OPENAI_MODEL }}
         run: |
           mapfile -t FILES_ARR < files.txt
           python -m scripts.translate_with_gpt \

--- a/scripts/translate_with_gpt.py
+++ b/scripts/translate_with_gpt.py
@@ -1,5 +1,6 @@
 import argparse
 import csv
+import os
 import re
 from pathlib import Path
 from typing import List, Tuple
@@ -8,7 +9,7 @@ from markdown.extensions.toc import slugify
 from openai import OpenAI
 
 # Constants and regex patterns (non-public)
-_GPT_MODEL = 'gpt-5-chat-latest'
+_GPT_MODEL = os.getenv('OPENAI_MODEL') or 'gpt-5.4'
 _MAX_WORKERS = 10
 _HEADING = re.compile(r'^(?: {0,3})(#{1,6})[ \t]+(.+?)\s*$')
 _ID_AT_END = re.compile(r'\s\{#([^}]+)\}\s*$')
@@ -154,7 +155,6 @@ def _translate_text(text: str, prompt: str) -> str:
     """
     response = _client.responses.create(
         model=_GPT_MODEL,
-        temperature=0,
         input=[
             {
                 'role': 'developer',


### PR DESCRIPTION
## Summary

- read the OpenAI translation model from the `OPENAI_MODEL` repository variable
- default to `gpt-5.4` when the variable is unset
- omit `temperature` to preserve compatibility when switching models

## Background

The translation workflow currently fails because the hard-coded `gpt-5-chat-latest` model is not available. Moving the model selection to an Actions variable allows future model changes without modifying the translation script.