### PR TITLE
fix(i18n): stabilize translation generation

### DIFF
--- a/scripts/translate_with_gpt.py
+++ b/scripts/translate_with_gpt.py
@@ -155,6 +155,8 @@ def _translate_text(text: str, prompt: str) -> str:
     """
     response = _client.responses.create(
         model=_GPT_MODEL,
+        reasoning={'effort': 'none'},
+        temperature=0,
         input=[
             {
                 'role': 'developer',


### PR DESCRIPTION
## Summary

- set `reasoning.effort` to `none`
- set `temperature` to `0` to reduce translation variance when unchanged sections are translated again

## Background

PR #26 made the OpenAI model configurable and defaulted it to `gpt-5.4`. This follow-up explicitly configures deterministic-style generation settings for the translation workflow.

`temperature=0` reduces variance but does not guarantee byte-identical API output.