### PR TITLE
Fix MaterialX theme configuration for the LLM site

### DIFF
--- a/config/ja-llm/mkdocs.yml
+++ b/config/ja-llm/mkdocs.yml
@@ -24,7 +24,7 @@ theme:
   favicon: assets/images/favicon.ico
   palette:
     primary: black
-  name: material
+  name: materialx
   font:
     text: Mulish
     code: SF Mono


### PR DESCRIPTION
## Summary

- update the LLM-specific MkDocs configuration to use the installed `materialx` theme
- restore the Firebase deployment build after the upstream migration from `mkdocs-material` to `mkdocs-materialx`

## Verification

- installed the current `requirements.txt` in a clean virtual environment
- ran `make -f Makefile.llm build` successfully

The existing navigation and link warnings remain unchanged and do not fail the build.