### PR TITLE
Restore the dark top bar on the LLM site

### DIFF
--- a/config/ja-llm/mkdocs.yml
+++ b/config/ja-llm/mkdocs.yml
@@ -22,6 +22,7 @@ theme:
   logo: assets/images/logo.png
   logo_light_mode: assets/images/logo.png
   favicon: assets/images/favicon.ico
+  topbar_style: primary
   palette:
     primary: black
   name: materialx


### PR DESCRIPTION
## Summary

- configure the MaterialX top bar to use the existing black primary palette
- restore the dark header appearance that was lost during the MaterialX migration

## Cause

MaterialX defaults `topbar_style` to `glass`. As a result, `palette.primary: black` no longer controls the top bar unless `topbar_style: primary` is explicitly configured.

## Verification

- ran `make -f Makefile.llm build` successfully with `mkdocs-materialx==10.1.5`
- verified that the generated page contains `data-md-color-primary="black"` and `data-mx-topbar="primary"`
- verified that the generated MaterialX CSS maps the primary top bar background to `--md-primary-fg-color`